### PR TITLE
Fix cross note link navigation

### DIFF
--- a/api/JoplinWorkspace.d.ts
+++ b/api/JoplinWorkspace.d.ts
@@ -93,5 +93,13 @@ export default class JoplinWorkspace {
      * Gets the IDs of the selected notes (can be zero, one, or many). Use the data API to retrieve information about these notes.
      */
     selectedNoteIds(): Promise<string[]>;
+
+    /**
+     * Gets the last hash (note section ID) from cross-note link targeting specific section.
+     * New hash is available after `onNoteSelectionChange()` is triggered.
+     * Example of cross-note link where `hello-world` is a hash: [Other Note Title](:/9bc9a5cb83f04554bf3fd3e41b4bb415#hello-world).
+     * Method returns empty value when a note was navigated with method other than cross-note link containing valid hash.
+     */
+    selectedNoteHash(): Promise<string>;
 }
 export {};

--- a/src/cursorTracker.ts
+++ b/src/cursorTracker.ts
@@ -32,13 +32,13 @@ module.exports = {
 
 				CodeMirror.registerCommand('rn.setCursor', function(message: any) {
 					const cm: EditorView = CodeMirror.editor;
-					const { line, ch, selection, restoreScrollPosition } = message;
+					const { line, ch, selection } = message;
 					const lineInfo = cm.state.doc.line(line);
 					// Calculate the exact position by adding the character offset to the line start
 					const pos = lineInfo.from + ch;	
 					cm.dispatch({
 						selection: { anchor: pos, head: selection ? pos + selection : pos },
-						scrollIntoView: restoreScrollPosition,
+						scrollIntoView: true,
 					});
 				});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,11 @@ let saveFolderNote: boolean = true;
 let useUserData: boolean = false;
 let saveSelection: boolean = true;
 let restoreDelay: number = 300;
-let noteNotLoaded: boolean = true;
+// dictates if scroll/cursor positions are being saved into memory in a loop
+let noteLoaded: boolean = false;
+let lastRecordedNoteId: string = '';
+let lastRecordedFolderId: string = '';
+let beforeLastRecordedFolderId: string = '';
 
 interface CursorPosition {
 	line: number;
@@ -98,9 +102,9 @@ joplin.plugins.register({
 				public: true,
 				section: 'resumenote',
 				label: 'Delay before setting cursor and scroll position (in ms)',
-				description: 'Delay before setting the cursor and scroll position after opening a note in the editor.',
+				description: 'Delay before setting the cursor and scroll position after opening a note in the editor. You might want to increase it if you often see that plugin performs restore correctly, but something overwrites it right after.',
 				minimum: 0,
-				maximum: 2000,
+				maximum: 10000,
 				step: 50,
 			},
 			'resumenote.startupDelay': {
@@ -255,14 +259,14 @@ joplin.plugins.register({
 			await joplin.commands.execute('openNote', startupNote);
 			setTimeout(async () => {
 				if (!versionInfo.mobile) {
-					// We're not in the mobile app	
-					await restoreCursorPosition(startupNote);
+					// We're not in the mobile app
+					noteLoaded = await restoreCursorPosition(startupNote);
 					return;
 				}
 				// We're in the mobile app
 				if (toggleEditor) {
 					await joplin.commands.execute('toggleVisiblePanes');
-					await restoreCursorPosition(startupNote);
+					noteLoaded = await restoreCursorPosition(startupNote);
 				}
 			}, 2*restoreDelay);
 		}
@@ -272,18 +276,56 @@ joplin.plugins.register({
 
 		// Update cursor position on note selection change
 		await joplin.workspace.onNoteSelectionChange(async () => {
-			noteNotLoaded = true;
+			console.debug("On Note Selection Change [In Progress].");
 			let note = await joplin.workspace.selectedNote();
-			if (!note) return;
+			let folder = await joplin.workspace.selectedFolder();
+
+			if (lastRecordedNoteId === note?.id) {
+				console.debug("On Note Selection Change [Cancel]. Reason: Duplicated execution. Note ID: " + lastRecordedNoteId);
+				return;
+			}
+
+			lastRecordedNoteId = note?.id;
+			beforeLastRecordedFolderId = lastRecordedFolderId;
+			lastRecordedFolderId = folder?.id;
+
+			// pause cursor/scroll saves into memory until 'On Note Selection Change' handler successfully executed
+			noteLoaded = false;
+			if (!note) {
+				console.debug(`On Note Selection Change [Cancel]. Reason: no selected note discovered.`);
+				return;
+			}
 			currentNoteId = note.id;
 			const createdTime = note.created_time;
 			const newFolderId = note.parent_id;
 			note = clearObjectReferences(note);
+			let newFolderManuallySelected = await isNewFolderManuallySelected();
+
+			console.debug(`New Folder Manually Selected: ${newFolderManuallySelected}`);
 
 			// Update the last note ID
 			await joplin.settings.setValue('resumenote.lastNoteId', currentNoteId);
 
-			if (newFolderId !== currentFolderId) {
+			if (newFolderId === currentFolderId) {
+				// Update both in-memory map and settings
+				await updateFolderNoteMap(currentFolderId, currentNoteId);
+			}
+
+			// Hash is ID of the note's section.
+			// If available on note selection change - user specifically wants to be scrolled to section of other note by Joplin core.
+			// Hash is not available on note selection change during general note switching.
+			// Avoid setting pos. from memory to not overwrite Joplin's scroll position to section.
+			let newNoteHash = await joplin.workspace.selectedNoteHash();
+			if (newNoteHash != null && newNoteHash.length > 0) {
+				console.debug(`On Note Selection Change [Cancel]. Reason: cross-note link contains hash #${newNoteHash}.`);
+				// keep cursor/scroll scanning active
+				noteLoaded = true;
+				return;
+			}
+			// Open folder's default note only during manual folder click, otherwise we overwrite cross-note links targeting
+			// note in other folder.
+			if (newFolderManuallySelected && (newFolderId !== currentFolderId)) {
+				console.debug("Open folder's default note [In Progress]. Reason: manual folder change detected.");
 				currentFolderId = newFolderId;
 
 				// Check if we have a saved note for the new folder
@@ -291,31 +333,30 @@ joplin.plugins.register({
 				if (savedNoteId) {
 					// Navigate to the saved note
 					await joplin.commands.execute('openNote', savedNoteId);
+					console.debug("Open folder's default note [Done].");
+				} else {
+					console.debug("Open folder's default note [Cancel]. Reason: not set yet.");
 				}
-
-			} else {
-				// Update both in-memory map and settings
-				await updateFolderNoteMap(currentFolderId, currentNoteId);
 			}
 
 			if (!versionInfo.mobile) {
 				// We're not in the mobile app
 				// If we have a saved cursor position for this note, restore it
-				await restoreCursorPosition(currentNoteId);
-				return;
+				noteLoaded = await restoreCursorPosition(currentNoteId);
+			} else {
+				// We're in the mobile app
+				const toggleEditor = await joplin.settings.value('resumenote.toggleEditor');
+				const currentTime = Date.now();
+				const noteAge = currentTime - createdTime;
+				// Note must be older than 10 seconds (new note is already in edit mode)
+				if (toggleEditor && noteAge > 1000*10) {
+					await new Promise(resolve => setTimeout(resolve, 100)); // Wait for the note to be opened
+					await joplin.commands.execute('toggleVisiblePanes');
+					noteLoaded = await restoreCursorPosition(currentNoteId);
+				}
+				// Do nothing or else it will fail
 			}
-
-			// We're in the mobile app
-			const toggleEditor = await joplin.settings.value('resumenote.toggleEditor');
-			const currentTime = Date.now();
-			const noteAge = currentTime - createdTime;
-			// Note must be older than 10 seconds (new note is already in edit mode)
-			if (toggleEditor && noteAge > 1000*10) {
-				await new Promise(resolve => setTimeout(resolve, 100)); // Wait for the note to be opened
-				await joplin.commands.execute('toggleVisiblePanes');
-				await restoreCursorPosition(currentNoteId);
-			}
-			return; // Do nothing or else it will fail
+			console.debug(`On Note Selection Change [Done]`);
 		});
 
 		// Update settings
@@ -347,7 +388,8 @@ joplin.plugins.register({
 });
 
 // Helper functions to update / load both the in-memory map, settings and user data
-async function updateFolderNoteMap(folderId: string, noteId: string): Promise<void> {  
+async function updateFolderNoteMap(folderId: string, noteId: string): Promise<void> {
+	console.debug(`Save default note for folder [In Progress]. Note ID: ${noteId}; Folder ID: ${folderId}`);
 	if (!saveFolderNote) return;
 	if (useUserData) {
 		// Store in userData
@@ -359,6 +401,7 @@ async function updateFolderNoteMap(folderId: string, noteId: string): Promise<vo
 		// Update settings
 		await joplin.settings.setValue('resumenote.folderNoteMap', JSON.stringify(folderNoteMap));
 	}
+	console.debug(`Save default note for folder [Done]. Note ID: ${noteId}; Folder ID: ${folderId}`);
 }
 
 async function loadFolderNoteMap(folderId: string): Promise<string> {
@@ -376,12 +419,10 @@ async function loadFolderNoteMap(folderId: string): Promise<string> {
 
 // Functions to handle cursor position
 async function updateCursorPosition(): Promise<void> {
-	if (!currentNoteId) return;
-	if (noteNotLoaded) return;
-
-    // Check if we're in code view
-    const isCodeView = await joplin.settings.globalValue('editor.codeView');
-    if (!isCodeView) return;  // Only proceed if in code view
+	const isCodeView = await joplin.settings.globalValue('editor.codeView');
+	if (!currentNoteId || !noteLoaded || !isCodeView) {
+		return;
+	}
 
 	let cursor: { line: number, ch: number, scroll: number, selection: number };
 	try {
@@ -411,42 +452,75 @@ async function updateCursorPosition(): Promise<void> {
 	}
 }
 
+/**
+ * Reads cursor/scroll positions ({@link CursorPosition}) from memory.
+ * Memory varies depending on plugin setting:
+ * - user settings (single device memory);
+ * - user data (sync across devices).
+ * @param noteId - ID of currently opened note.
+ * @returns boolean indicating if note is loaded properly:
+ *          - true if no cursor/scroll position found in memory, or if restore went well;
+ *          - false if editor is not "code view", or there was error during positions restore.
+ */
 async function loadCursorPosition(noteId: string): Promise<CursorPosition | undefined> {
-  // Load from userData
+	console.debug("Load saved cursor & scroll [In Progress]. Note ID: " + currentNoteId);
+	let savedCursor: CursorPosition;
 	if (useUserData) {
-		const savedCursor: CursorPosition = await joplin.data.userDataGet(ModelType.Note, currentNoteId, 'cursor');
-		return savedCursor;
+		savedCursor = await joplin.data.userDataGet(ModelType.Note, currentNoteId, 'cursor');
+	} else {
+		// Load from memory
+		savedCursor = noteCursorMap[noteId];
 	}
-  	// Load from memory
-	return noteCursorMap[noteId];
+	console.debug(`Load saved cursor & scroll [Done]. Value: ${JSON.stringify(savedCursor)}; Note ID: ${currentNoteId}`);
+  	return savedCursor;
 }
 
-async function restoreCursorPosition(noteId: string): Promise<void> {
+/**
+ * Restores cursor/scroll position of provided note from memory.
+ * Skips restore if:
+ * - no cursor/scroll position was found in memory;
+ * - note is opened in editor other than "code view" (Markdown);
+ * - error happened (not re-thrown) meaning editor is likely not available.
+ * Uses custom 'CodeMirror 6' commands registered in `cursorTracker.ts`.
+ * @see ./cursorTracker.ts for custom 'CodeMirror 6' commands.
+ * @param noteId - ID of currently opened note.
+ * @returns boolean indicating if note is loaded properly:
+ *          - true if no cursor/scroll position found in memory, or if restore went well;
+ *          - false if editor is not "code view", or there was error during positions restore.
+ */
+async function restoreCursorPosition(noteId: string): Promise<boolean> {
+	console.debug(`Restore cursor position [In Progress]. Note ID: ${noteId}.`);
 	const savedCursor = await loadCursorPosition(noteId);
+	// setting that controls whether the editor displays notes in "code view" (Markdown source) or another mode, like
+	// the rich text (WYSIWYG) editor.
 	const isCodeView = await joplin.settings.globalValue('editor.codeView');
-	if (!isCodeView) return;  // Only proceed if in code view
-
-	if (savedCursor) {
-		await joplin.commands.execute('editor.focus');
-		await new Promise(resolve => setTimeout(resolve, restoreDelay));
-		try {
-			await joplin.commands.execute('editor.execCommand', {
-				name: 'rn.setCursor',
-				args: [ { line: savedCursor.scroll, ch: 1, selection: 0 } ]
-			});
-			await joplin.commands.execute('editor.execCommand', {
-				name: 'rn.setScroll',
-				args: [ savedCursor ]
-			});
-			await joplin.commands.execute('editor.execCommand', {
-				name: 'rn.setCursor',
-				args: [ savedCursor ]
-			});
-		} catch (error) {
-			// If the command fails, it means the editor is not available
-		}
+	if (!isCodeView) return false;  // Only proceed if in code view
+	if (!savedCursor) {
+		return true;
 	}
-	noteNotLoaded = false;
+
+	await joplin.commands.execute('editor.focus');
+	await new Promise(resolve => setTimeout(resolve, restoreDelay));
+	try {
+		await joplin.commands.execute('editor.execCommand', {
+			name: 'rn.setCursor',
+			args: [ { line: savedCursor.scroll, ch: 1, selection: 0 } ]
+		});
+		await joplin.commands.execute('editor.execCommand', {
+			name: 'rn.setScroll',
+			args: [ savedCursor ]
+		});
+		await joplin.commands.execute('editor.execCommand', {
+			name: 'rn.setCursor',
+			args: [ savedCursor ]
+		});
+	} catch (error) {
+		// If the command fails, it means the editor is not available
+		console.debug(`Restore cursor position [Failed]. Note ID: ${noteId}. Reason: editor is not available`);
+		return false;
+	}
+	console.debug(`Restore cursor position [Done]. Note ID: ${noteId}.`);
+	return true;
 }
 
 // Clear all note / folder properties
@@ -491,6 +565,25 @@ async function clearUserData(): Promise<void> {
 async function clearSettingsData(): Promise<void> {
 	await joplin.settings.setValue('resumenote.folderNoteMap', '{}');
 	await joplin.settings.setValue('resumenote.noteCursorMap', '{}');
+}
+
+/**
+ * Checks if manual note folder switch happened rather than user navigated to new folder
+ * through cross-note link.
+ * When user clicks on note folder Joplin core code loads some note out of the folder and
+ * then plugin comes in to overwrite it with last opened note in this folder.
+ *
+ * lastRecordedNoteId - during folder click Joplin API returns empty value when current note is requested, we record
+ * empty value in lastRecordedNoteId to indicate folder selection.
+ * lastRecordedFolderId - new folder ID recorded during folder click;
+ * beforeLastRecordedFolderId - previous folder ID.
+ * @returns true if: no lastRecordedNoteId (folder click) and new folder ID differs from prev. folder ID.
+ */
+async function isNewFolderManuallySelected(): Promise<boolean> {
+	return (lastRecordedNoteId?.length < 1)
+		&& lastRecordedFolderId?.length > 0
+		&& beforeLastRecordedFolderId?.length > 0
+		&& beforeLastRecordedFolderId !== lastRecordedFolderId;
 }
 
 export function clearObjectReferences(obj: any): null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,13 +53,6 @@ joplin.plugins.register({
 				label: 'Save the last active note in each folder. Requires restart.',
 				description: 'This setting is not yet supported on mobile devices.',
 			},
-			'resumenote.restoreScrollPosition': {
-				value: true,
-				type: SettingItemType.Bool,
-				public: true,
-				section: 'resumenote',
-				label: 'Restore scroll position.',
-			},
 			'resumenote.noteCursorMap': {
 				value: '{}',
 				type: SettingItemType.String,
@@ -429,11 +422,9 @@ async function loadCursorPosition(noteId: string): Promise<CursorPosition | unde
 }
 
 async function restoreCursorPosition(noteId: string): Promise<void> {
-	const savedCursor = await loadCursorPosition(noteId) as CursorPosition & { restoreScrollPosition: boolean };
+	const savedCursor = await loadCursorPosition(noteId);
 	const isCodeView = await joplin.settings.globalValue('editor.codeView');
 	if (!isCodeView) return;  // Only proceed if in code view
-	const restoreScrollPosition = await joplin.settings.value('resumenote.restoreScrollPosition');
-	savedCursor.restoreScrollPosition = restoreScrollPosition;
 
 	if (savedCursor) {
 		await joplin.commands.execute('editor.focus');
@@ -441,14 +432,12 @@ async function restoreCursorPosition(noteId: string): Promise<void> {
 		try {
 			await joplin.commands.execute('editor.execCommand', {
 				name: 'rn.setCursor',
-				args: [ { line: savedCursor.scroll, ch: 1, selection: 0, restoreScrollPosition: restoreScrollPosition } ]
+				args: [ { line: savedCursor.scroll, ch: 1, selection: 0 } ]
 			});
-			if (restoreScrollPosition) {
-				await joplin.commands.execute('editor.execCommand', {
-					name: 'rn.setScroll',
-					args: [ savedCursor ]
-				});
-			}
+			await joplin.commands.execute('editor.execCommand', {
+				name: 'rn.setScroll',
+				args: [ savedCursor ]
+			});
 			await joplin.commands.execute('editor.execCommand', {
 				name: 'rn.setCursor',
 				args: [ savedCursor ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 1,
 	"id": "joplin.plugin.alondmnt.sticky-note",
-	"app_min_version": "3.2",
+	"app_min_version": "3.3.4",
 	"platforms": ["mobile", "desktop"],
 	"version": "0.3.2",
 	"name": "Resume Note",


### PR DESCRIPTION
## Purpose
When testing "Resume Note" plugin on latest pre-release version of Joplin 2 bugs were discovered related to cross-note link navigation.
### Plugin breaks cross-note anchor (hash) navigation
Referenced issue: [here](https://github.com/alondmnt/joplin-plugin-resume-note/issues/3).
Description: plugin ignores (proceeds with restore from memory) scroll position set by Joplin when user clicks a cross-note link targeting specific section.
### Plugin mistakenly restores folder's last note during cross-note link navigation targeting note in other folder
Referenced issue: none
Description: when navigating to a cross-note link—whether it includes a hash or not—that points to a note in a different folder, the plugin incorrectly prioritizes restoring the last opened note in that folder. This overrides the user's intent to open the specific target note, causing unexpected behavior.

## What was done?
### Fixed cross-note anchor (hash) navigation
Fixed by skipping scroll/position restore process when hash value (section ID) is detected in cross-note link during navigation.

Method responsible for hash value gathering is `joplin.workspace.selectedNoteHash()`.
It was merged into Joplin Core specifically for purpose of this PR: [Commit](https://github.com/laurent22/joplin/commit/bd49f3b2805787577c372a3d84e08c2f78a6d720) (bd49f3b).

### Fixed plugin mistakenly restoring folder's default note during cross-note link navigation targeting note in other folder
Fixed by checking if manual note folder switch happened rather than user navigated to new folder through cross-note link.
If manual note folder switch - proceed with folder's last note restore, else - skip restore.
Check is performed by new `isNewFolderManuallySelected` method.
During folder click Joplin API returns empty value when current note is requested, we record empty value in lastRecordedNoteId to indicate folder selection.

### Other minor changes
- reverted previous [commit ](https://github.com/alondmnt/joplin-plugin-resume-note/commit/f586d6d173969ac1ea788048b0f2538dae83d2a7) (kept the version number change). As it was discussed in [here](https://github.com/alondmnt/joplin-plugin-resume-note/issues/3) the fix was not reliable;
- increased min. supported Joplin version to 3.3.4 (latest pre-release), but it should be updated to whatever version we'll see on [Joplin Releases](https://github.com/laurent22/joplin/releases) in future containing Joplin API improvement [commit](https://github.com/laurent22/joplin/commit/bd49f3b2805787577c372a3d84e08c2f78a6d720) (bd49f3b) involved in this PR;
- increased max value for plugin setting `resumenote.restoreDelay` to be 10 sec instead of 2 sec because Joplin sometimes performs its own post-render scrolls too late overwriting the restored cursor/scroll positions. Seems to be even worse when PC is under load further suggesting that increase of this setting might be helpful for low-end device users;
- `noteNotLoaded` variable was inverted to `noteLoaded` for better understanding of the code. It dictates if scroll/cursor positions are being saved into memory in a loop;
- `restoreCursorPosition` now returns `noteLoaded` to keep the method serving it's single purpose and maintain scroll/cursor position scan toggling on the higher level;
- skip duplicated `onNoteSelectionChange` trigger execution - not sure why this happens, but 2 simutaneous processes handling same event are no good here;
- logging improvements.

## Testing
Manual testing performed on latest Joplin pre-release v3.3.4.
Mobile testing was **NOT** performed!!!
This PR doesn't touch mobile chunks of code, but it's still important to test everything out on mobile.
Unfortunately I don't know how to test this on mobile - figuring this out...

## Note for reviewer
Given that this PR contains revert of previous commit I suggest specifically looking at diff of the following commit:
https://github.com/alondmnt/joplin-plugin-resume-note/pull/4/commits/8f180c84ee879effd71c425b6d6ce9a43ff83b7c

Also sorry for including everything at once in one commit, I was fighting the thought of not doing this PR at all and keeping this all to myself and so when I decided to release it - it was already all there tied to each other and I have no time at this point to shift different changes to different commits.

## ❌ Do not merge until
This PR relies on Joplin Plugin API core containing functionality that was not released yet.
Track [Joplin Releases](https://github.com/laurent22/joplin/releases) in future containing Joplin API improvement [commit](https://github.com/laurent22/joplin/commit/bd49f3b2805787577c372a3d84e08c2f78a6d720) (bd49f3b).

Do this when you see that latest stable release contains bd49f3b:
- update min. supported Joplin version to whatever is Joplin release number;
- test the plugin including this PR fixes on latest Joplin stable release;
- merge this PR if it's all good;
- ask maintainers to release a new plugin version.